### PR TITLE
refactor: Vite 개발 서버에 host: true 설정 추가

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
     tailwindcss()
   ],
   server: {
+    host: true,
     port: 3000,
   },
   resolve: {


### PR DESCRIPTION
IPv4(127.0.0.1)에서도 접근 가능하도록 Vite 개발 서버의
host 옵션을 true로 설정합니다.