### PR TITLE
feat(auth): PKCE 인가코드 로그인 (OAuth2 5단계)

### DIFF
--- a/src/entities/session/api/sessionApi.ts
+++ b/src/entities/session/api/sessionApi.ts
@@ -20,6 +20,26 @@ export const sessionApi = {
   },
 
   /**
+   * OAuth2 인가코드(code)를 HR 토큰으로 교환 (PKCE)
+   * SSO 로그인 후 받은 일회용 code 와 code_verifier 로 HR JWT(HttpOnly 쿠키)를 발급받습니다.
+   */
+  exchangeCode: async (params: {
+    code: string
+    codeVerifier: string
+    redirectUri: string
+  }): Promise<TokenExchangeResponse> => {
+    const resp: ApiResponse<TokenExchangeResponse> = await apiClient.request({
+      method: 'post',
+      url: `/auth/exchange-code`,
+      data: params
+    })
+
+    if (!resp.success) throw new Error(resp.message)
+
+    return resp.data
+  },
+
+  /**
    * 로그아웃 (HttpOnly 쿠키 삭제)
    */
   logout: async (): Promise<void> => {

--- a/src/features/auth/lib/pkce.ts
+++ b/src/features/auth/lib/pkce.ts
@@ -1,0 +1,58 @@
+/**
+ * OAuth 2.0 PKCE (Proof Key for Code Exchange) 유틸.
+ * - code_verifier: 43~128자 base64url 랜덤 (crypto.getRandomValues)
+ * - code_challenge: base64url(SHA-256(code_verifier)) — S256
+ * - state: CSRF 방어용 랜덤
+ *
+ * SSO 로그인 시작 시 verifier/state 를 만들어 sessionStorage 에 잠깐 보관하고,
+ * 콜백(?code=)에서 token 교환에 사용한 뒤 즉시 삭제한다(영구 저장 금지).
+ */
+
+const VERIFIER_KEY = 'pkce_code_verifier'
+const STATE_KEY = 'pkce_state'
+
+/** Uint8Array → base64url (padding 제거). */
+function toBase64Url(bytes: Uint8Array): string {
+  let binary = ''
+  for (const b of bytes) binary += String.fromCharCode(b)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+/** code_verifier 생성 (32바이트 → base64url ≈ 43자). */
+export function generateCodeVerifier(): string {
+  const bytes = new Uint8Array(32)
+  crypto.getRandomValues(bytes)
+  return toBase64Url(bytes)
+}
+
+/** code_challenge = base64url(SHA-256(verifier)). */
+export async function codeChallenge(verifier: string): Promise<string> {
+  const data = new TextEncoder().encode(verifier)
+  const digest = await crypto.subtle.digest('SHA-256', data)
+  return toBase64Url(new Uint8Array(digest))
+}
+
+/** state 생성 (16바이트 → base64url). */
+export function generateState(): string {
+  const bytes = new Uint8Array(16)
+  crypto.getRandomValues(bytes)
+  return toBase64Url(bytes)
+}
+
+export function savePkce(verifier: string, state: string): void {
+  sessionStorage.setItem(VERIFIER_KEY, verifier)
+  sessionStorage.setItem(STATE_KEY, state)
+}
+
+export function getCodeVerifier(): string | null {
+  return sessionStorage.getItem(VERIFIER_KEY)
+}
+
+export function getSavedState(): string | null {
+  return sessionStorage.getItem(STATE_KEY)
+}
+
+export function clearPkce(): void {
+  sessionStorage.removeItem(VERIFIER_KEY)
+  sessionStorage.removeItem(STATE_KEY)
+}

--- a/src/features/auth/ui/LoginContent.tsx
+++ b/src/features/auth/ui/LoginContent.tsx
@@ -7,6 +7,7 @@ import { Spinner } from '@/shared/ui/shadcn/spinner';
 import { useTheme } from '@/shared/ui/shadcn/themeProvider';
 import { config } from '@/shared/config'
 import { cn } from '@/shared/lib'
+import { generateCodeVerifier, codeChallenge, generateState, savePkce } from '@/features/auth/lib/pkce';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -52,18 +53,23 @@ const LoginForm = () => {
   const { theme } = useTheme();
   const [isRedirecting, setIsRedirecting] = useState(false);
 
-  // SSO 로그인 URL 생성
-  const getSsoLoginUrl = () => {
-    const ssoUrl = config.ssoUrl;
-    // 현재 페이지를 callback URL로 설정
-    const callbackUrl = `${window.location.origin}/auth/callback`;
-    return `${ssoUrl}/login?redirect_uri=${encodeURIComponent(callbackUrl)}`;
-  };
-
-  // SSO로 리다이렉트
-  const handleSsoRedirect = () => {
+  // SSO로 리다이렉트 (PKCE 인가코드 흐름)
+  // code_verifier/state 를 생성·보관하고 code_challenge(S256) 를 인가 요청에 첨부한다.
+  const handleSsoRedirect = async () => {
     setIsRedirecting(true);
-    window.location.href = getSsoLoginUrl();
+    const verifier = generateCodeVerifier();
+    const state = generateState();
+    savePkce(verifier, state);
+    const challenge = await codeChallenge(verifier);
+    const callbackUrl = `${window.location.origin}/auth/callback`;
+    const params = new URLSearchParams({
+      redirect_uri: callbackUrl,
+      client_id: 'hr',
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+      state,
+    });
+    window.location.href = `${config.ssoUrl}/login?${params.toString()}`;
   };
 
   // 자동 리다이렉트 (선택적 - 필요시 활성화)

--- a/src/pages/auth-callback/ui/AuthCallbackPage.tsx
+++ b/src/pages/auth-callback/ui/AuthCallbackPage.tsx
@@ -1,5 +1,6 @@
 import Loading from '@/shared/ui/loading/Loading';
 import { sessionApi } from '@/entities/session';
+import { getCodeVerifier, getSavedState, clearPkce } from '@/features/auth/lib/pkce';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -14,7 +15,40 @@ const AuthCallbackPage = () => {
 
   useEffect(() => {
     const handleCallback = async () => {
-      // URL fragment에서 토큰 추출 (예: /auth/callback#token=xxx)
+      // 신규: OAuth2 Authorization Code + PKCE (?code=&state=)
+      const query = new URLSearchParams(window.location.search);
+      const code = query.get('code');
+      if (code) {
+        const returnedState = query.get('state');
+        const savedState = getSavedState();
+        const verifier = getCodeVerifier();
+        // verifier 없거나 state(CSRF) 불일치 시 거부
+        if (!verifier || (savedState && returnedState && savedState !== returnedState)) {
+          clearPkce();
+          setError('인증 상태 검증에 실패했습니다.');
+          setTimeout(() => navigate('/login', { replace: true }), 3000);
+          return;
+        }
+        try {
+          const redirectUri = `${window.location.origin}/auth/callback`;
+          await sessionApi.exchangeCode({ code, codeVerifier: verifier, redirectUri });
+          clearPkce();
+          window.history.replaceState({}, '', window.location.pathname);
+          navigate('/dashboard', { replace: true });
+        } catch (err) {
+          console.error('Code exchange failed:', err);
+          clearPkce();
+          setError(
+            err instanceof Error
+              ? err.message
+              : 'HR 서비스 접근 권한이 없거나 인가코드 교환에 실패했습니다.'
+          );
+          setTimeout(() => navigate('/login', { replace: true }), 3000);
+        }
+        return;
+      }
+
+      // 기존(병행): URL fragment 의 SSO 토큰 (예: /auth/callback#token=xxx)
       const hash = window.location.hash;
       const params = new URLSearchParams(hash.substring(1)); // # 제거
       const ssoToken = params.get('token');


### PR DESCRIPTION
## 무엇을
HR 웹 로그인을 OAuth 2.0 **PKCE Authorization Code** 흐름으로 전환. 기존 `#token=` fragment 수신은 콜백에서 **병행 지원**(점진 전환). desk-front 패턴 미러.

## 변경
- `features/auth/lib/pkce.ts` (신규) — `generateCodeVerifier`(base64url), `codeChallenge`(S256, Web Crypto `crypto.subtle.digest`), `generateState`, 세션 보관/조회/정리
- `LoginContent` — `handleSsoRedirect` async화: verifier/state 생성·보관 → SSO URL 에 `client_id=hr&code_challenge&code_challenge_method=S256&state`
- `AuthCallbackPage` — `?code=` 우선(state CSRF 검증 → `exchangeCode`), 없으면 `#token=` 폴백
- `sessionApi.exchangeCode` — `POST /auth/exchange-code {code, codeVerifier, redirectUri}`

## 의존
hr-back `/auth/exchange-code`(병렬 작업), SSO `clients` 의 `hr` 등록·콜백 redirect_uri 화이트리스트.

## 검증
변경 파일 `tsc --noEmit` 0 errors, `build:skip-check`(vite) 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ6zai1TYL9DDd48uVCTs7