### PR TITLE
feat(admin): 관리자 비밀번호 리셋을 임시비번 자동발송 방식으로 변경 (#8e-3)

### DIFF
--- a/i18n/translations.csv
+++ b/i18n/translations.csv
@@ -1276,9 +1276,9 @@ vacation,history.empty.typeStats.title,휴가 유형 통계가 없습니다,No V
 vacation,history.empty.typeStats.description,사용 가능한 휴가 유형이 없습니다,No available vacation types
 admin,user.passwordReset,비밀번호 초기화,Reset Password
 admin,user.passwordResetTitle,비밀번호 초기화,Reset Password
-admin,user.passwordResetDesc,{{name}} 사용자의 비밀번호를 초기화합니다.,Reset the password for user {{name}}.
-admin,user.newPassword,새 비밀번호,New Password
-admin,user.newPasswordPlaceholder,새 비밀번호를 입력하세요,Enter new password
+admin,user.passwordResetConfirm,{{name}} 사용자의 비밀번호를 초기화하면 임시 비밀번호가 사용자 이메일로 발송됩니다. 계속하시겠습니까?,Resetting the password for user {{name}} will send a temporary password to their email. Do you want to continue?
+admin,user.passwordResetSuccess,임시 비밀번호를 사용자 이메일로 발송했습니다.,A temporary password has been sent to the user's email.
+admin,user.passwordResetError,비밀번호 초기화에 실패했습니다.,Failed to reset the password.
 admin,user.resetting,초기화 중...,Resetting...
 admin,user.reset,초기화,Reset
 login,forgotPassword,비밀번호를 잊으셨나요?,Forgot your password?

--- a/src/entities/user/api/userApi.ts
+++ b/src/entities/user/api/userApi.ts
@@ -177,10 +177,7 @@ export const userApi = {
   resetPassword: async (data: ResetPasswordReq): Promise<void> => {
     const resp: ApiResponse = await apiClient.request({
       method: 'patch',
-      url: `/users/${data.user_id}/password`,
-      data: {
-        new_password: data.new_password
-      }
+      url: `/users/${data.user_id}/password`
     })
 
     if (!resp.success) throw new Error(resp.message)

--- a/src/entities/user/model/types.ts
+++ b/src/entities/user/model/types.ts
@@ -183,7 +183,6 @@ export interface UpdateDashboardResp {
 
 export interface ResetPasswordReq {
   user_id: string
-  new_password: string
 }
 
 // 비밀번호 초기화 요청 (비로그인)

--- a/src/features/admin-users-management/ui/UserPasswordResetDialog.tsx
+++ b/src/features/admin-users-management/ui/UserPasswordResetDialog.tsx
@@ -9,10 +9,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/shared/ui/shadcn/dialog'
-import { Input } from '@/shared/ui/shadcn/input'
-import { Label } from '@/shared/ui/shadcn/label'
+import { toast } from '@/shared/ui/shadcn/sonner'
 import { Spinner } from '@/shared/ui/shadcn/spinner'
-import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 interface UserPasswordResetDialogProps {
@@ -26,50 +24,33 @@ const UserPasswordResetDialog = ({ open, onOpenChange, userId, userName }: UserP
   const { t } = useTranslation('admin')
   const { t: tc } = useTranslation('common')
   const { mutateAsync: resetPassword, isPending } = useResetPasswordMutation()
-  const [password, setPassword] = useState('')
 
   const handleConfirm = async () => {
-    if (!password.trim()) return
-    await resetPassword({ user_id: userId, new_password: password })
-    setPassword('')
-    onOpenChange(false)
-  }
-
-  const handleOpenChange = (open: boolean) => {
-    if (!open) {
-      setPassword('')
+    try {
+      await resetPassword({ user_id: userId })
+      toast.success(t('user.passwordResetSuccess'))
+      onOpenChange(false)
+    } catch (error) {
+      toast.error((error as Error).message || t('user.passwordResetError'))
     }
-    onOpenChange(open)
   }
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>{t('user.passwordResetTitle')}</DialogTitle>
           <DialogDescription>
-            {t('user.passwordResetDesc', { name: userName })}
+            {t('user.passwordResetConfirm', { name: userName })}
           </DialogDescription>
         </DialogHeader>
-        <div className="py-4">
-          <Label htmlFor="password">{t('user.newPassword')}</Label>
-          <Input
-            id="password"
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            placeholder={t('user.newPasswordPlaceholder')}
-            className="mt-2"
-            disabled={isPending}
-          />
-        </div>
         <DialogFooter>
           <DialogClose asChild>
             <Button type="button" variant="secondary" disabled={isPending}>
               {tc('cancel')}
             </Button>
           </DialogClose>
-          <Button onClick={handleConfirm} disabled={isPending || !password.trim()}>
+          <Button onClick={handleConfirm} disabled={isPending}>
             {isPending ? (
               <>
                 <Spinner className="h-4 w-4 mr-2" />


### PR DESCRIPTION
## 배경
hr 비밀번호 흐름이 SSO 연동으로 바뀌었다. 관리자 리셋은 이제 hr-back `PATCH /api/v1/users/{userId}/password`(body 없음) 호출 → SSO 가 **임시 비밀번호를 자동 생성해 사용자 이메일로 발송**한다(관리자가 새 비번을 직접 지정하지 않음). 기존 hr-front 관리자 리셋 다이얼로그는 '관리자가 새 비번 직접 입력' 방식이라 맞지 않아 '리셋 확인 → 임시비번 이메일 발송' UX 로 변경.

## 변경 사항
- **types.ts**: `ResetPasswordReq` 에서 `new_password` 제거 → `{ user_id: string }` 만.
- **userApi.ts**: `resetPassword` body 제거. 데이터 없이 `PATCH /users/{user_id}/password` 호출.
- **UserPasswordResetDialog.tsx**: 새 비번 `Input`/`Label`/`password` state 제거 → 확인 다이얼로그(안내 문구 + 확인/취소)로 전환. 확인 시 `resetPassword({ user_id })` → 성공/실패 토스트(`toast.success/error`).
- **i18n(translations.csv)**: `admin user.passwordResetConfirm/passwordResetSuccess/passwordResetError`(ko/en) 추가, 사용처 없어진 `passwordResetDesc`/`newPassword`/`newPasswordPlaceholder` 제거. `npm run i18n:generate` 실행 완료.

## 범위 밖(미변경)
- 본인 비밀번호 변경(`PasswordChangeDialog`, current/new/confirm) — hr-back `/users/me/password` 와 이미 일치.
- 분실 리셋(`requestPasswordReset`) — 별도 작업(8e-4, sso-front 담당).

## 검증
- `npm run build:skip-check` 통과 (이 레포는 TS 에러로 일반 build 대신 skip-check 사용).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ6zai1TYL9DDd48uVCTs7