### PR TITLE
fix(auth): OAuth2 콜백 code 중복 교환 방지 (StrictMode 가드)

### DIFF
--- a/src/pages/auth-callback/ui/AuthCallbackPage.tsx
+++ b/src/pages/auth-callback/ui/AuthCallbackPage.tsx
@@ -1,7 +1,7 @@
 import Loading from '@/shared/ui/loading/Loading';
 import { sessionApi } from '@/entities/session';
 import { getCodeVerifier, getSavedState, clearPkce } from '@/features/auth/lib/pkce';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 /**
@@ -12,8 +12,12 @@ import { useNavigate } from 'react-router-dom';
 const AuthCallbackPage = () => {
   const navigate = useNavigate();
   const [error, setError] = useState<string | null>(null);
+  // StrictMode/재렌더로 effect 가 2번 돌아도 일회용 code 를 단 한 번만 교환하도록 가드
+  const calledRef = useRef(false);
 
   useEffect(() => {
+    if (calledRef.current) return;
+    calledRef.current = true;
     const handleCallback = async () => {
       // 신규: OAuth2 Authorization Code + PKCE (?code=&state=)
       const query = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## 배경
React 19 `<StrictMode>` 가 개발모드에서 `useEffect` 를 2회 실행 → `AuthCallbackPage` 의 `sessionApi.exchangeCode({ code, ... })` 가 같은 일회용 authorization code 로 2번 호출됨. 하나는 성공, 다른 하나는 SSO 400(이미 소비)으로 실패하고, 실패 핸들러의 `navigate('/login')` 이 마지막에 먹혀 로그인 화면으로 바운스되는 버그.

## 수정
- `src/pages/auth-callback/ui/AuthCallbackPage.tsx` 에 `const calledRef = useRef(false)` 추가.
- `useEffect` 본문 맨 앞에서 `if (calledRef.current) return; calledRef.current = true;` 로 code 교환을 정확히 1회만 실행.
- StrictMode 는 같은 인스턴스로 effect 를 재실행하므로 ref 가 유지돼 2회차가 차단됨.
- StrictMode 와 나머지 콜백 로직(code/state/verifier 검증, exchangeToken 병행 경로, error 처리, navigate)은 그대로 유지. 가드만 추가.

## 검증
- `npm run build:skip-check` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ6zai1TYL9DDd48uVCTs7