### PR TITLE
chore: remove legacy OAuth #token fragment consumption

### DIFF
--- a/src/entities/session/api/sessionApi.ts
+++ b/src/entities/session/api/sessionApi.ts
@@ -4,22 +4,6 @@ import type { GetLoginCheck, TokenExchangeResponse } from '@/entities/session/mo
 
 export const sessionApi = {
   /**
-   * SSO 토큰을 HR 토큰으로 교환
-   * SSO에서 발급한 JWT를 HR 서비스용 JWT로 교환합니다.
-   */
-  exchangeToken: async (ssoToken: string): Promise<TokenExchangeResponse> => {
-    const resp: ApiResponse<TokenExchangeResponse> = await apiClient.request({
-      method: 'post',
-      url: `/auth/exchange`,
-      data: { ssoToken }
-    })
-
-    if (!resp.success) throw new Error(resp.message)
-
-    return resp.data
-  },
-
-  /**
    * OAuth2 인가코드(code)를 HR 토큰으로 교환 (PKCE)
    * SSO 로그인 후 받은 일회용 code 와 code_verifier 로 HR JWT(HttpOnly 쿠키)를 발급받습니다.
    */

--- a/src/pages/auth-callback/ui/AuthCallbackPage.tsx
+++ b/src/pages/auth-callback/ui/AuthCallbackPage.tsx
@@ -52,48 +52,11 @@ const AuthCallbackPage = () => {
         return;
       }
 
-      // 기존(병행): URL fragment 의 SSO 토큰 (예: /auth/callback#token=xxx)
-      const hash = window.location.hash;
-      const params = new URLSearchParams(hash.substring(1)); // # 제거
-      const ssoToken = params.get('token');
-      const errorParam = params.get('error');
-
-      if (errorParam) {
-        setError(decodeURIComponent(errorParam));
-        // 3초 후 로그인 페이지로 이동
-        setTimeout(() => {
-          navigate('/login', { replace: true });
-        }, 3000);
-        return;
-      }
-
-      if (ssoToken) {
-        try {
-          // SSO 토큰을 HR 토큰으로 교환 (HR JWT는 HttpOnly Cookie로 자동 설정됨)
-          await sessionApi.exchangeToken(ssoToken);
-
-          // URL에서 토큰 제거 (보안)
-          window.history.replaceState({}, '', window.location.pathname);
-
-          // 대시보드로 이동
-          navigate('/dashboard', { replace: true });
-        } catch (err) {
-          console.error('Token exchange failed:', err);
-          setError(
-            err instanceof Error
-              ? err.message
-              : 'HR 서비스 접근 권한이 없거나 토큰 교환에 실패했습니다.'
-          );
-          setTimeout(() => {
-            navigate('/login', { replace: true });
-          }, 3000);
-        }
-      } else {
-        setError('인증 토큰을 받지 못했습니다.');
-        setTimeout(() => {
-          navigate('/login', { replace: true });
-        }, 3000);
-      }
+      // code 가 없으면 인증 실패 처리
+      setError('인증 토큰을 받지 못했습니다.');
+      setTimeout(() => {
+        navigate('/login', { replace: true });
+      }, 3000);
     };
 
     handleCallback();


### PR DESCRIPTION
## 요약
로그인이 PKCE `?code=` 진입으로만 이루어져 dead 코드가 된 SSO fragment 토큰(`#token`) 소비 경로를 제거합니다. (hr 는 desk 미러 구조이며 `#token` 이 dead 임이 확인됨)

## 변경
- `AuthCallbackPage.tsx`: `window.location.hash` 기반 `#token` / `errorParam` / `exchangeToken` 분기 삭제. `?code=` (PKCE) 분기는 유지하고, `code` 가 없을 때는 `'인증 토큰을 받지 못했습니다.'` fallback 에러 표시로 처리되게 재배치.
- `sessionApi.ts`: `exchangeToken`(`POST /auth/exchange`) 제거. `exchangeCode`(`/auth/exchange-code`) 유지.

## 검증
- `npm run build:skip-check` 그린 (built in 5.74s).
- `grep -rn "exchangeToken\|#token\|location.hash" src` 0건.

## 주의
- hr 는 dev 미검증입니다. 배포 후 실제 hr 로그인(PKCE `?code=`) 정상 동작 실측이 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01EJ6zai1TYL9DDd48uVCTs7