### PR TITLE
chore: OAuth 마이그레이션 이후 미사용 VITE_APP_TITLE env 정리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
-VITE_APP_TITLE="porest"
 VITE_BASE_URL=http://localhost:8001
 VITE_API_URL=/api/v1
 VITE_SSO_URL=http://localhost:3000

--- a/src/shared/config/env.ts
+++ b/src/shared/config/env.ts
@@ -1,12 +1,10 @@
 interface Config {
-  appTitle: string
   baseUrl: string
   apiBaseUrl: string
   ssoUrl: string
 }
 
 export const config: Config = {
-  appTitle: import.meta.env.VITE_APP_TITLE,
   baseUrl: import.meta.env.VITE_BASE_URL,
   apiBaseUrl: `${import.meta.env.VITE_BASE_URL}${import.meta.env.VITE_API_URL}`,
   ssoUrl: import.meta.env.VITE_SSO_URL || '',

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,9 +1,9 @@
 /// <reference types='vite/client' />
 
 interface ImportMetaEnv {
-  readonly VITE_APP_TITLE: string
   readonly VITE_BASE_URL: string
   readonly VITE_API_URL: string
+  readonly VITE_SSO_URL: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## 배경
OAuth 2.0 + PKCE 마이그레이션 완료 이후 hr-front 의 `.env.example` 을 최신 기준으로 정리합니다. 조사 결과 `VITE_APP_TITLE` 이 실사용되지 않는 죽은 값으로 확인되어 제거합니다.

## 변경 사항
- **.env.example**: `VITE_APP_TITLE` 제거
  - 근거: `config.appTitle` 참조 0건, `index.html` 이 `<title>porest</title>` 로 하드코딩되어 `%VITE_APP_TITLE%` 치환도 사용하지 않음
- **src/shared/config/env.ts**: `Config.appTitle` 타입 필드 및 `import.meta.env.VITE_APP_TITLE` 할당 라인 제거
- **src/vite-env.d.ts**: `VITE_APP_TITLE` 선언 제거 + 실사용 중(`env.ts` 의 `config.ssoUrl`)인 `VITE_SSO_URL` 선언 추가 (타입 정합성 보강)

## 유지된 키 (실사용 확인)
- `VITE_BASE_URL`, `VITE_API_URL` → `config.apiBaseUrl`(axios baseURL), `config.baseUrl`(프로필 이미지 URL)
- `VITE_SSO_URL` → `config.ssoUrl`(SSO 로그인/회원가입 리다이렉트)

## OAuth 레거시 잔재 점검 (모두 이미 제거 확인)
- `#token`/`location.hash` fragment 토큰 파싱: 없음 (콜백은 `?code=`+`state` 만 처리)
- 구 `exchangeToken`: 없음 (`exchangeCode`/`/auth/exchange-code` 만 존재)
- `VITE_DEFAULT_REDIRECT_URL`/`defaultRedirectUrl`: 코드·예제 모두 없음
- PKCE(`?code`): 정상 (로그인 진입점이 S256 challenge/state 강제)

## 비고
- `.env.local` 은 비추적(gitignore) 파일이라 이 PR 에서 수정하지 않았습니다. 로컬에서 개별 제거 필요.
- `SignUpContent.tsx` 중복(`features/auth/ui/` vs `features/auth/components/`)은 이번 범위 밖입니다.

## 게이트
- `npm run build:skip-check` 통과 (built in 5.19s, 에러 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWKMwi8y3PDSmJNz5jrKyK